### PR TITLE
Add optional parameters to the vcd task waiting for VM to boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ vm_mem: 'VM RAM in GB'
 
 Other variables that can be overridden:
 
-    check_connection_timeout: 600
+    check_connection_timeout: 300
 
-Change the 'timeout' param of 'wait_for_connection' module. Default is 600 seconds (same as 'wait_for_connection' module default).
+Change the 'timeout' param of 'wait_for' module. Default is 300 seconds (same as 'wait_for' module default).
 
     check_connection_delay: 0
 
-Change the 'delay' param of 'wait_for_connection' module. Default is 0 second (same as 'wait_for_connection' module default).
+Change the 'delay' param of 'wait_for' module. Default is 0 second (same as 'wait_for' module default).
 
     check_connection_sleep: 1
 
-Change the 'sleep' param of 'wait_for_connection' module. Default is 1 second (same as 'wait_for_connection' module default).
+Change the 'sleep' param of 'wait_for' module. Default is 1 second (same as 'wait_for' module default).
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ state: 'configures teh state of the VM/vApp' - must one of the allowed valued fo
 vm_cpu: 'number of vCPU for the VM'
 vm_mem: 'VM RAM in GB'
 
+Other variables that can be overridden:
+
+    check_connection_timeout: 600
+
+Change the 'timeout' param of 'wait_for_connection' module. Default is 600 seconds (same as 'wait_for_connection' module default).
+
+    check_connection_delay: 0
+
+Change the 'delay' param of 'wait_for_connection' module. Default is 0 second (same as 'wait_for_connection' module default).
+
+    check_connection_sleep: 1
+
+Change the 'sleep' param of 'wait_for_connection' module. Default is 1 second (same as 'wait_for_connection' module default).
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,11 +3,11 @@
 
 ssh_key_file: ".ssh/id_rsa"
 
-# To override 'timeout' param of 'wait_for_connection' module:
-check_connection_timeout: 600
+# To override 'timeout' param of 'wait_for' module:
+check_connection_timeout: 300
 
-# To override 'delay' param of 'wait_for_connection' module:
+# To override 'delay' param of 'wait_for' module:
 check_connection_delay: 0
 
-# To override 'sleep' param of 'wait_for_connection' module:
+# To override 'sleep' param of 'wait_for' module:
 check_connection_sleep: 1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,12 @@
 # defaults file for ansible-vcd
 
 ssh_key_file: ".ssh/id_rsa"
+
+# To override 'timeout' param of 'wait_for_connection' module:
+check_connection_timeout: 600
+
+# To override 'delay' param of 'wait_for_connection' module:
+check_connection_delay: 0
+
+# To override 'sleep' param of 'wait_for_connection' module:
+check_connection_sleep: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,9 +42,12 @@
 
     vapp_name: "{{ vm_name }}"
 
-- name: Waiting until remote system is reachable/usable (for VM to boot)
-  wait_for_connection:
-    connect_timeout: "{{ check_connection_timeout }}"
+- name: Waiting for VM to boot
+  wait_for:
+    port: 22
+    host: "{{ vm_ip }}"
+    search_regex: SSH
+    timeout: "{{ check_connection_timeout }}"
     delay: "{{ check_connection_delay }}"
     sleep: "{{ check_connection_sleep }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
 
 - name: Waiting until remote system is reachable/usable (for VM to boot)
   wait_for_connection:
-    timeout: "{{ check_connection_timeout }}"
+    connect_timeout: "{{ check_connection_timeout }}"
     delay: "{{ check_connection_delay }}"
     sleep: "{{ check_connection_sleep }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,14 +42,11 @@
 
     vapp_name: "{{ vm_name }}"
 
-- name: Waiting for VM to boot (min 90s)
-  wait_for:
-    port: 22
-    host: "{{ vm_ip }}"
-    search_regex: SSH
-    #delay: 90
-    #Sleep available from version 2.3
-    #sleep: 10
+- name: Waiting until remote system is reachable/usable (for VM to boot)
+  wait_for_connection:
+    timeout: "{{ check_connection_timeout }}"
+    delay: "{{ check_connection_delay }}"
+    sleep: "{{ check_connection_sleep }}"
 
 - name: Retrieve VM infos
   vca_vapp:
@@ -94,7 +91,7 @@
     name: "{{ vm_ip }}"
     key: "{{ keyscan.stdout }}"
     path: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
-  when: 
+  when:
     - not keyscan | skipped
 
 - name: Trying to log into VM (using ssh key)


### PR DESCRIPTION
The goal of this PR is to add ability to set timeout, delay or sleep to the vcd task waiting for VM to boot using the wait_for Ansible module.

New default vars:
  * check_connection_timeout
  * check_connection_delay
  * check_connection_sleep